### PR TITLE
Remove disabled property and aria-disabled attribute

### DIFF
--- a/vaadin-radio-button-group.html
+++ b/vaadin-radio-button-group.html
@@ -54,7 +54,6 @@ This program is available under Apache License Version 2.0, available at https:/
        * `required`   | Set when the radio group is required for submission of the form and must have value.
        *
        * @memberof Vaadin
-       * @mixes Vaadin.ControlStateMixin
        * @mixes Vaadin.ThemableMixin
        * @element vaadin-radio-button-group
        * @demo demo/index.html

--- a/vaadin-radio-button.html
+++ b/vaadin-radio-button.html
@@ -118,14 +118,6 @@ This program is available under Apache License Version 2.0, available at https:/
               reflectToAttribute: true
             },
 
-            /**
-             * The current disabled state of the radio button. True if disabled.
-             */
-            disabled: {
-              type: Boolean,
-              reflectToAttribute: true,
-              observer: '_disabledChanged'
-            },
 
             /**
              * The name of the control, which is submitted with the form data.
@@ -162,14 +154,6 @@ This program is available under Apache License Version 2.0, available at https:/
           }
 
           this.dispatchEvent(new CustomEvent('change', {bubbles: true}));
-        }
-
-        _disabledChanged(disabled) {
-          if (disabled) {
-            this.setAttribute('aria-disabled', 'true');
-          } else {
-            this.removeAttribute('aria-disabled');
-          }
         }
 
         _addActiveListeners() {


### PR DESCRIPTION
Connects to https://github.com/vaadin/vaadin-control-state-mixin/pull/12

Remove `disabled` property and `aria-disabled` attribute as it is added in control-state-mixin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-radio-button/7)
<!-- Reviewable:end -->
