### PR TITLE
Update Valo

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -18,10 +18,96 @@
       },
       "elements": [
         {
-          "description": "`<vaadin-radio-button>` is a Polymer element for radio buttons.\n\n```html\n<vaadin-radio-button value=\"foo\">Foo</vaadin-radio-button>\n```\n\n### Styling\n\nThe following shadow DOM parts are available for styling:\n\nPart name         | Description\n------------------|----------------\n`wrapper`         | The `<label>` element which wrapps the radio button and [part=\"label\"]\n`native-radio`    | The `<input type=\"radio\">` element\n`radio`           | The `<span>` element for a custom graphical radio button\n`label`           | The `<span>` element for slotted text/HTML label\n\nThe following state attributes are available for styling:\n\nAttribute  | Description | Part name\n-----------|-------------|------------\n`disabled`   | Set when the radio button is disabled. | :host\n`focus-ring` | Set when the radio button is focused using the keyboard. | :host\n`focused`    | Set when the radio button is focused. | :host\n`checked`    | Set when the radio button is checked. | :host\n\nSee [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)",
+          "description": "`<vaadin-radio-button>` is a Polymer element for radio buttons.\n\n```html\n<vaadin-radio-button value=\"foo\">Foo</vaadin-radio-button>\n```\n\n### Styling\n\nThe following shadow DOM parts are available for styling:\n\nPart name         | Description\n------------------|----------------\n`radio`           | The radio button element\n`label`           | The label content element\n\nThe following state attributes are available for styling:\n\nAttribute  | Description | Part name\n-----------|-------------|------------\n`disabled`   | Set when the radio button is disabled. | :host\n`focus-ring` | Set when the radio button is focused using the keyboard. | :host\n`focused`    | Set when the radio button is focused. | :host\n`checked`    | Set when the radio button is checked. | :host\n\nSee [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)",
           "summary": "",
           "path": "src/vaadin-radio-button.html",
           "properties": [
+            {
+              "name": "autofocus",
+              "type": "boolean",
+              "description": "Specify that this control should have input focus when the page loads.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 50,
+                  "column": 8
+                },
+                "end": {
+                  "line": 52,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "_previousTabIndex",
+              "type": "number",
+              "description": "Stores the previous value of tabindex attribute of the disabled element",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 57,
+                  "column": 8
+                },
+                "end": {
+                  "line": 59,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "disabled",
+              "type": "boolean",
+              "description": "If true, the user cannot interact with this element.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 64,
+                  "column": 8
+                },
+                "end": {
+                  "line": 68,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "observer": "\"_disabledChanged\""
+                }
+              },
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "_isShiftTabbing",
+              "type": "boolean",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 70,
+                  "column": 8
+                },
+                "end": {
+                  "line": 72,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
             {
               "name": "name",
               "type": "string",
@@ -29,11 +115,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 113,
+                  "line": 144,
                   "column": 10
                 },
                 "end": {
-                  "line": 113,
+                  "line": 144,
                   "column": 20
                 }
               },
@@ -50,11 +136,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 87,
+                  "line": 118,
                   "column": 12
                 },
                 "end": {
-                  "line": 93,
+                  "line": 124,
                   "column": 13
                 }
               },
@@ -73,11 +159,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 98,
+                  "line": 129,
                   "column": 12
                 },
                 "end": {
-                  "line": 101,
+                  "line": 132,
                   "column": 13
                 }
               },
@@ -94,11 +180,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 124,
+                  "line": 155,
                   "column": 8
                 },
                 "end": {
-                  "line": 132,
+                  "line": 163,
                   "column": 9
                 }
               },
@@ -106,16 +192,284 @@
               "params": []
             },
             {
+              "name": "connectedCallback",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 118,
+                  "column": 4
+                },
+                "end": {
+                  "line": 123,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "disconnectedCallback",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 128,
+                  "column": 4
+                },
+                "end": {
+                  "line": 133,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "_setFocused",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 135,
+                  "column": 4
+                },
+                "end": {
+                  "line": 149,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "focused"
+                }
+              ],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "_bodyKeydownListener",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 151,
+                  "column": 4
+                },
+                "end": {
+                  "line": 153,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "_bodyKeyupListener",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 155,
+                  "column": 4
+                },
+                "end": {
+                  "line": 157,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "_focus",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 168,
+                  "column": 4
+                },
+                "end": {
+                  "line": 175,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "focus",
+              "description": "Moving the focus from the host element causes firing of the blur event what leads to problems in IE.",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 181,
+                  "column": 4
+                },
+                "end": {
+                  "line": 188,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "blur",
+              "description": "Native bluring in the host element does nothing because it does not have the focus.\nIn chrome it works, but not in FF.",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 195,
+                  "column": 4
+                },
+                "end": {
+                  "line": 198,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "_disabledChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 200,
+                  "column": 4
+                },
+                "end": {
+                  "line": 213,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "disabled"
+                }
+              ],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "_tabindexChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 215,
+                  "column": 4
+                },
+                "end": {
+                  "line": 231,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "tabindex"
+                }
+              ],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "_addEventListenerToNode",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "../bower_components/polymer/lib/mixins/gesture-event-listeners.html",
+                "start": {
+                  "line": 47,
+                  "column": 6
+                },
+                "end": {
+                  "line": 51,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node"
+                },
+                {
+                  "name": "eventName"
+                },
+                {
+                  "name": "handler"
+                }
+              ],
+              "inheritedFrom": "Polymer.GestureEventListeners"
+            },
+            {
+              "name": "_removeEventListenerFromNode",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "../bower_components/polymer/lib/mixins/gesture-event-listeners.html",
+                "start": {
+                  "line": 53,
+                  "column": 6
+                },
+                "end": {
+                  "line": 57,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node"
+                },
+                {
+                  "name": "eventName"
+                },
+                {
+                  "name": "handler"
+                }
+              ],
+              "inheritedFrom": "Polymer.GestureEventListeners"
+            },
+            {
               "name": "_checkedChanged",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 134,
+                  "line": 165,
                   "column": 8
                 },
                 "end": {
-                  "line": 136,
+                  "line": 167,
                   "column": 9
                 }
               },
@@ -132,11 +486,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 138,
+                  "line": 169,
                   "column": 8
                 },
                 "end": {
-                  "line": 167,
+                  "line": 198,
                   "column": 9
                 }
               },
@@ -149,11 +503,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 173,
+                  "line": 204,
                   "column": 8
                 },
                 "end": {
-                  "line": 175,
+                  "line": 206,
                   "column": 9
                 }
               },
@@ -165,7 +519,31 @@
               ]
             }
           ],
-          "staticMethods": [],
+          "staticMethods": [
+            {
+              "name": "_includeStyle",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-themable-mixin/vaadin-themable-mixin.html",
+                "start": {
+                  "line": 46,
+                  "column": 4
+                },
+                "end": {
+                  "line": 50,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "moduleName"
+                }
+              ],
+              "inheritedFrom": "Vaadin.ThemableMixin"
+            }
+          ],
           "demos": [
             {
               "url": "demo/index.html",
@@ -175,11 +553,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 73,
+              "line": 99,
               "column": 6
             },
             "end": {
-              "line": 176,
+              "line": 207,
               "column": 7
             }
           },
@@ -188,15 +566,51 @@
           "name": "Vaadin.RadioButtonElement",
           "attributes": [
             {
+              "name": "autofocus",
+              "description": "Specify that this control should have input focus when the page loads.",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 50,
+                  "column": 8
+                },
+                "end": {
+                  "line": 52,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "boolean",
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "disabled",
+              "description": "If true, the user cannot interact with this element.",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 64,
+                  "column": 8
+                },
+                "end": {
+                  "line": 68,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "boolean",
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
               "name": "checked",
               "description": "True if the radio button is checked.",
               "sourceRange": {
                 "start": {
-                  "line": 87,
+                  "line": 118,
                   "column": 12
                 },
                 "end": {
-                  "line": 93,
+                  "line": 124,
                   "column": 13
                 }
               },
@@ -208,11 +622,11 @@
               "description": "The value for this element.",
               "sourceRange": {
                 "start": {
-                  "line": 98,
+                  "line": 129,
                   "column": 12
                 },
                 "end": {
-                  "line": 101,
+                  "line": 132,
                   "column": 13
                 }
               },
@@ -239,11 +653,11 @@
               "range": {
                 "file": "src/vaadin-radio-button.html",
                 "start": {
-                  "line": 31,
+                  "line": 57,
                   "column": 8
                 },
                 "end": {
-                  "line": 31,
+                  "line": 57,
                   "column": 21
                 }
               }
@@ -251,8 +665,10 @@
           ],
           "tagname": "vaadin-radio-button",
           "mixins": [
+            "Vaadin.ElementMixin",
             "Vaadin.ControlStateMixin",
-            "Vaadin.ThemableMixin"
+            "Vaadin.ThemableMixin",
+            "Polymer.GestureEventListeners"
           ]
         },
         {
@@ -587,7 +1003,31 @@
               ]
             }
           ],
-          "staticMethods": [],
+          "staticMethods": [
+            {
+              "name": "_includeStyle",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-themable-mixin/vaadin-themable-mixin.html",
+                "start": {
+                  "line": 46,
+                  "column": 4
+                },
+                "end": {
+                  "line": 50,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "moduleName"
+                }
+              ],
+              "inheritedFrom": "Vaadin.ThemableMixin"
+            }
+          ],
           "demos": [
             {
               "url": "demo/index.html",

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "polymer": "^2.0.0",
     "vaadin-control-state-mixin": "^2.0.0",
     "vaadin-themable-mixin": "^1.1.0",
-    "vaadin-valo-theme": "^2.0.0",
+    "vaadin-valo-styles": "vaadin/vaadin-valo-styles#^2.0.0",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^1.0.1"
   },
   "devDependencies": {
@@ -38,6 +38,6 @@
     "iron-test-helpers": "^2.0.0",
     "vaadin-button": "^2.0.0",
     "web-component-tester": "^6.1.5",
-    "vaadin-demo-helpers": "^1.0.0"
+    "vaadin-demo-helpers": "^1.2.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,11 +6,9 @@
   <title>vaadin-radio-button Examples</title>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-  <style>
-    body {
-      font-family: sans-serif;
-    }
-  </style>
+  <custom-style>
+    <style include="vaadin-component-demo-shared-styles"></style>
+  </custom-style>
 </head>
 
 <body>

--- a/demo/radio-button-basic-demos.html
+++ b/demo/radio-button-basic-demos.html
@@ -1,6 +1,6 @@
 <dom-module id="radio-button-basic-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
        :host {
         display: block;
       }

--- a/demo/radio-group-demos.html
+++ b/demo/radio-group-demos.html
@@ -1,6 +1,6 @@
 <dom-module id="radio-group-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
       :host {
         display: block;
       }

--- a/demo/radio-group-valo-theme-demos.html
+++ b/demo/radio-group-valo-theme-demos.html
@@ -1,6 +1,6 @@
 <dom-module id="radio-group-valo-theme-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
       :host {
         display: block;
       }

--- a/src/vaadin-radio-button.html
+++ b/src/vaadin-radio-button.html
@@ -13,21 +13,47 @@ This program is available under Apache License Version 2.0, available at https:/
 <dom-module id="vaadin-radio-button">
   <template>
     <style>
+      :host {
+        display: inline-block;
+      }
+
+      #label {
+        display: inline-flex;
+        align-items: baseline;
+        outline: none;
+      }
+
+      [part="radio"] {
+        position: relative;
+        display: inline-block;
+        flex: none;
+      }
+
+      #nativeRadioButton {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        opacity: 0;
+        cursor: inherit;
+      }
+
       :host([disabled]) {
         -webkit-tap-highlight-color: transparent;
       }
     </style>
 
-    <label part="wrapper" on-click="_preventDefault">
-      <input
-        type="radio"
-        part="native-radio"
-        checked="{{checked::change}}"
-        disabled$="[[disabled]]"
-        role="presentation"
-        tabindex="-1">
-
-      <span part="radio"></span>
+    <label id="label" on-click="_preventDefault">
+      <span part="radio">
+        <input
+          type="radio"
+          id="nativeRadioButton"
+          checked="{{checked::change}}"
+          disabled$="[[disabled]]"
+          role="presentation"
+          tabindex="-1">
+      </span>
 
       <span part="label">
         <slot></slot>
@@ -50,10 +76,8 @@ This program is available under Apache License Version 2.0, available at https:/
        *
        * Part name         | Description
        * ------------------|----------------
-       * `wrapper`         | The `<label>` element which wrapps the radio button and [part="label"]
-       * `native-radio`    | The `<input type="radio">` element
-       * `radio`           | The `<span>` element for a custom graphical radio button
-       * `label`           | The `<span>` element for slotted text/HTML label
+       * `radio`           | The radio button element
+       * `label`           | The label content element
        *
        * The following state attributes are available for styling:
        *
@@ -169,7 +193,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         get focusElement() {
-          return this.shadowRoot.querySelector('[part="wrapper"]');
+          return this.$.label;
         }
 
         _preventDefault(e) {

--- a/src/vaadin-radio-button.html
+++ b/src/vaadin-radio-button.html
@@ -17,7 +17,7 @@ This program is available under Apache License Version 2.0, available at https:/
         display: inline-block;
       }
 
-      #label {
+      label {
         display: inline-flex;
         align-items: baseline;
         outline: none;
@@ -29,7 +29,7 @@ This program is available under Apache License Version 2.0, available at https:/
         flex: none;
       }
 
-      #nativeRadioButton {
+      input[type="radio"] {
         position: absolute;
         top: 0;
         left: 0;
@@ -44,11 +44,10 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     </style>
 
-    <label id="label" on-click="_preventDefault">
+    <label on-click="_preventDefault">
       <span part="radio">
         <input
           type="radio"
-          id="nativeRadioButton"
           checked="{{checked::change}}"
           disabled$="[[disabled]]"
           role="presentation"
@@ -193,7 +192,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         get focusElement() {
-          return this.$.label;
+          return this.shadowRoot.querySelector('label');
         }
 
         _preventDefault(e) {

--- a/src/vaadin-radio-button.html
+++ b/src/vaadin-radio-button.html
@@ -90,12 +90,19 @@ This program is available under Apache License Version 2.0, available at https:/
        * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
        *
        * @memberof Vaadin
+       * @mixes Vaadin.ElementMixin
        * @mixes Vaadin.ControlStateMixin
        * @mixes Vaadin.ThemableMixin
+       * @mixes Polymer.GestureEventListeners
        * @element vaadin-radio-button
        * @demo demo/index.html
        */
-      class RadioButtonElement extends Vaadin.ElementMixin(Vaadin.ControlStateMixin(Vaadin.ThemableMixin(Polymer.GestureEventListeners(Polymer.Element)))) {
+      class RadioButtonElement extends
+        Vaadin.ElementMixin(
+          Vaadin.ControlStateMixin(
+            Vaadin.ThemableMixin(
+              Polymer.GestureEventListeners(Polymer.Element)))) {
+
         static get is() {
           return 'vaadin-radio-button';
         }

--- a/test/vaadin-radio-button.html
+++ b/test/vaadin-radio-button.html
@@ -30,7 +30,7 @@
 
       beforeEach(() => {
         vaadinRadioButton = fixture('default');
-        nativeRadio = vaadinRadioButton.shadowRoot.querySelector('[part="native-radio"]');
+        nativeRadio = vaadinRadioButton.shadowRoot.querySelector('input');
         label = vaadinRadioButton.shadowRoot.querySelector('[part="label"]');
       });
 

--- a/theme/valo/vaadin-radio-button.html
+++ b/theme/valo/vaadin-radio-button.html
@@ -1,48 +1,23 @@
-<link rel="import" href="../../../vaadin-valo-theme/color.html">
-<link rel="import" href="../../../vaadin-valo-theme/style.html">
+<link rel="import" href="../../../vaadin-valo-styles/color.html">
+<link rel="import" href="../../../vaadin-valo-styles/style.html">
 
 <dom-module id="valo-radio-button" theme-for="vaadin-radio-button">
   <template>
     <style>
       :host {
-        display: inline-block;
-        -webkit-user-select: none;
-        color: var(--valo-body-text-color);
-      }
-
-      [part="wrapper"] {
-        display: flex;
-        align-items: baseline;
         -webkit-tap-highlight-color: transparent;
-        outline: none;
-      }
-
-      /* This makes the :active style work in IE11 */
-      [part="label"] {
-        pointer-events: none;
-        transition: transform 0.3s;
-        will-change: transform;
-      }
-
-      /* Not sure if this is necessary: should there ever be anything clickable inside the label? */
-      [part="label"] > * {
-        pointer-events: auto;
+        -webkit-user-select: none;
+        user-select: none;
+        cursor: default;
       }
 
       [part="label"]:not(:empty) {
         margin: 0.1875em 0.875em 0.1875em 0.375em;
       }
 
-      [part="native-radio"] {
-        opacity: 0;
-        position: absolute;
-      }
-
       [part="radio"] {
-        display: inline-block;
         width: calc(1em + 2px);
         height: calc(1em + 2px);
-        flex: none;
         margin: 0.1875em;
         position: relative;
         border-radius: 50%;
@@ -51,12 +26,6 @@
         pointer-events: none;
         will-change: transform;
         line-height: 1.2;
-      }
-
-      /* IE11 only */
-      ::-ms-backdrop,
-      [part="radio"] {
-        line-height: 1;
       }
 
       /* Used for activation "halo" */
@@ -91,7 +60,6 @@
         background-clip: content-box;
       }
 
-      :host([indeterminate]) [part="radio"],
       :host([checked]) [part="radio"] {
         background-color: var(--valo-primary-color);
       }
@@ -137,12 +105,13 @@
       }
 
       :host([disabled]) [part="radio"]::after {
-        border-color: var(--valo-contrast-40pct);
+        border-color: var(--valo-contrast-30pct);
       }
 
-      /* Similar workaround as for vaadin-checkbox issue: https://github.com/vaadin/vaadin-checkbox/issues/16 */
-      [part="native-radio"]:checked ~ [part="radio"] {
-        opacity: 1;
+      /* IE11 only */
+      ::-ms-backdrop,
+      [part="radio"] {
+        line-height: 1;
       }
     </style>
   </template>


### PR DESCRIPTION
Update vaadin-valo-styles and vaadin-demo-helpers dependencies.

Use shared demo styles.

Remove non-semantic `wrapper` and `native-radio` styling parts. The `radio` part should be used to display the visual checkbox.
- The non-semantic elements remain, but they are now considered internal implementation details. The layout specific CSS is moved to the core styles.

Don’t set the text color, as that should be inherited from the main page for the label content.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-radio-button/37)
<!-- Reviewable:end -->
