### PR TITLE
 Use bare module specifiers in the P3 conversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
       npm install -g yarn magi-cli polymer-cli@next &&
       (cd .. && git clone --depth 1 -b vaadin-components git://github.com/web-padawan/polymer-modulizer.git && cd polymer-modulizer && npm link) &&
       rm -rf node_modules &&
-      magi p3-convert --out . &&
+      magi p3-convert --out . --import-style=name &&
       yarn install --flat &&
       if [[ "$TRAVIS_EVENT_TYPE" = "pull_request" ]]; then
         xvfb-run -s '-screen 0 1024x768x24' polymer test --module-resolution=node --npm -l chrome;

--- a/test/vaadin-radio-button.html
+++ b/test/vaadin-radio-button.html
@@ -5,8 +5,7 @@
   <title>vaadin-radio-button tests</title>
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../iron-test-helpers/mock-interactions.js"></script>
-  <link rel="import" href="../../polymer/polymer.html">
+  <link rel="import" href="../../iron-test-helpers/mock-interactions.html">
   <link rel="import" href="../../iron-form/iron-form.html">
   <link rel="import" href="../vaadin-radio-button.html">
   <link rel="import" href="../vaadin-radio-group.html">

--- a/test/vaadin-radio-button.html
+++ b/test/vaadin-radio-button.html
@@ -7,6 +7,7 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../iron-test-helpers/mock-interactions.html">
   <link rel="import" href="../../iron-form/iron-form.html">
+  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-radio-button.html">
   <link rel="import" href="../vaadin-radio-group.html">
 </head>

--- a/test/vaadin-radio-group.html
+++ b/test/vaadin-radio-group.html
@@ -6,6 +6,7 @@
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../iron-test-helpers/mock-interactions.html">
+  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-radio-button.html">
   <link rel="import" href="../vaadin-radio-group.html">
 </head>

--- a/test/vaadin-radio-group.html
+++ b/test/vaadin-radio-group.html
@@ -5,8 +5,7 @@
   <title>vaadin-radio-button tests</title>
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../iron-test-helpers/mock-interactions.js"></script>
-  <link rel="import" href="../../polymer/polymer.html">
+  <link rel="import" href="../../iron-test-helpers/mock-interactions.html">
   <link rel="import" href="../vaadin-radio-button.html">
   <link rel="import" href="../vaadin-radio-group.html">
 </head>

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -18,7 +18,9 @@ module.exports = {
       'macOS 10.12/iphone@11.2',
       'macOS 10.12/ipad@11.2',
       'Windows 10/chrome@65',
-      'macOS 10.12/safari@11.0'
+      'macOS 10.12/safari@11.0',
+      'Windows 10/firefox@59',
+      'Windows 10/microsoftedge@16'
     ];
 
     var cronPlatforms = [


### PR DESCRIPTION
Connected to vaadin/components-team-tasks#332

The `mock-interactions` change is intended to  to eliminate the `polymer-legacy.js` import from converted tests, and is needed because of the fact that `mock-interactions.js` still use the `Polymer.Base.async` and the HTML file imports the correspondent dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-radio-button/54)
<!-- Reviewable:end -->
