### PR TITLE
Option to disable keyboard navigation

### DIFF
--- a/src/vaadin-radio-group.html
+++ b/src/vaadin-radio-group.html
@@ -34,6 +34,7 @@ This program is available under Apache License Version 2.0, available at https:/
        * Attribute  | Description | Part name
        * -----------|-------------|------------
        * `disabled`   | Set when the radio group and its children are disabled. | :host
+       * `disable-keyboard-nav` | Set to turn off the keyboard navigation for when using in shadow dom. | :host
        *
        * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
        *
@@ -70,6 +71,14 @@ This program is available under Apache License Version 2.0, available at https:/
               type: String,
               notify: true,
               observer: '_valueChanged'
+            },
+
+            /**
+             * Disable keyboard navigation
+             */
+            disableKeyboardNav: {
+              type: Boolean,
+              value: false
             }
           };
         }
@@ -131,7 +140,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.addEventListener('keydown', e => {
             // if e.target is vaadin-radio-group then assign to checkedRadioButton currently checked radio button
             var checkedRadioButton = (e.target == this) ? this._checkedButton : e.target;
-            if (this.disabled) {
+            if (this.disabled || this.disableKeyboardNav) {
               return;
             }
 


### PR DESCRIPTION
Event.target doesn’t work when element is used in the shadow dom; the target always resolves to the root element that is placed in the light-dom. Disable keyboard navigation to prevent problems when using in shadow dom.

See: #56

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-radio-button/58)
<!-- Reviewable:end -->
