### PR TITLE
Remove margin on input[type="radio"]

### DIFF
--- a/src/vaadin-radio-button.html
+++ b/src/vaadin-radio-button.html
@@ -37,6 +37,7 @@ This program is available under Apache License Version 2.0, available at https:/
         height: 100%;
         opacity: 0;
         cursor: inherit;
+        margin: 0;
       }
 
       :host([disabled]) {


### PR DESCRIPTION
I use the demo CDN to show an example.

With this `vaadin-radio-button`:

![screen shot 2018-05-10 at 19 23 38](https://user-images.githubusercontent.com/1007051/39883723-f81317c6-5487-11e8-9ed0-077d9b941c70.png)

The `input[type="radio"]` it's outside the `span[part="radio"]` right now:

![screen shot 2018-05-10 at 19 23 42](https://user-images.githubusercontent.com/1007051/39883736-0286cae0-5488-11e8-9a41-032867de4f94.png)

The `input[type="radio"]` with the PR change:

![screen shot 2018-05-10 at 19 24 10](https://user-images.githubusercontent.com/1007051/39883741-07870c6c-5488-11e8-840e-aa37ba14bfe0.png)

I recomend to open all the images in browser tabs, and move accross them to see easily.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-radio-button/60)
<!-- Reviewable:end -->
