### PR TITLE
Reorganize demos

### DIFF
--- a/demo/demos.json
+++ b/demo/demos.json
@@ -2,33 +2,44 @@
   "name": "Vaadin Radio Button",
   "pages": [
   {
-    "name": "Basic Examples",
+    "name": "Radio Button",
     "url": "radio-button-basic-demos",
     "src": "radio-button-basic-demos.html",
     "meta": {
-      "title": "vaadin-radio-button Basic Examples",
+      "title": "vaadin-radio-button Examples",
       "description": "",
       "image": ""
-     }
+    }
   }
   ,
   {
-    "name": "Vaadin Radio Group",
+    "name": "Radio Group",
     "url": "radio-group-demos",
     "src": "radio-group-demos.html",
     "meta": {
       "title": "vaadin-radio-group Examples",
       "description": "",
       "image": ""
-     }
+    }
   }
   ,
   {
-    "name": "Lumo Theme Variations",
+    "name": "Validation",
+    "url": "radio-group-validation-demos",
+    "src": "radio-group-validation-demos.html",
+    "meta": {
+      "title": "vaadin-radio-group Validation Examples",
+      "description": "",
+      "image": ""
+    }
+  }
+  ,
+  {
+    "name": "Theme Variants",
     "url": "radio-group-lumo-theme-demos",
     "src": "radio-group-lumo-theme-demos.html",
     "meta": {
-      "title": "vaadin-radio-button Lumo Theme Variations",
+      "title": "vaadin-radio-button Theme Variants",
       "description": "",
       "image": ""
     }

--- a/demo/radio-button-basic-demos.html
+++ b/demo/radio-button-basic-demos.html
@@ -7,17 +7,17 @@
     </style>
 
 
-    <h3>Default Radio</h3>
+    <h3>Radio Button</h3>
     <vaadin-demo-snippet id="radio-button-basic-demos-default-radio">
       <template preserve-content>
-        <vaadin-radio-button value="foo">Foo</vaadin-radio-button>
+        <vaadin-radio-button value="en">English</vaadin-radio-button>
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Disabled radio</h3>
+    <h3>Disabled Radio Button</h3>
     <vaadin-demo-snippet id="radio-button-basic-demos-disabled-radio">
       <template preserve-content>
-        <vaadin-radio-button disabled>Disabled radio</vaadin-radio-button>
+        <vaadin-radio-button disabled>Disabled</vaadin-radio-button>
       </template>
     </vaadin-demo-snippet>
 

--- a/demo/radio-group-demos.html
+++ b/demo/radio-group-demos.html
@@ -10,14 +10,14 @@
     <vaadin-demo-snippet id="radio-group-demos-radio-group-label">
       <template preserve-content>
         <vaadin-radio-group label="Risk level">
-          <vaadin-radio-button name="low">Low</vaadin-radio-button>
-          <vaadin-radio-button name="medium">Medium</vaadin-radio-button>
-          <vaadin-radio-button name="high">High</vaadin-radio-button>
+          <vaadin-radio-button value="low">Low</vaadin-radio-button>
+          <vaadin-radio-button value="medium">Medium</vaadin-radio-button>
+          <vaadin-radio-button value="high">High</vaadin-radio-button>
         </vaadin-radio-group>
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Radio Group Disabled</h3>
+    <h3>Disabled Radio Group</h3>
     <vaadin-demo-snippet id="radio-group-demos-radio-group-disabled">
       <template preserve-content>
         <vaadin-radio-group label="Mark" disabled>
@@ -27,86 +27,6 @@
           <vaadin-radio-button>4</vaadin-radio-button>
           <vaadin-radio-button>5</vaadin-radio-button>
         </vaadin-radio-group>
-      </template>
-    </vaadin-demo-snippet>
-
-    <h3>Radio Group with Value</h3>
-    <vaadin-demo-snippet id="radio-group-demos-radio-group-value">
-      <template preserve-content>
-        <dom-bind>
-          <template>
-            <vaadin-radio-group value="{{radioValue}}" label="Preferred language of contact">
-              <vaadin-radio-button value="en">English</vaadin-radio-button>
-              <vaadin-radio-button value="fr">Français</vaadin-radio-button>
-              <vaadin-radio-button value="de">Deutsch</vaadin-radio-button>
-            </vaadin-radio-group>
-            <p>Selected value: [[radioValue]]</p>
-          </template>
-        </dom-bind>
-      </template>
-    </vaadin-demo-snippet>
-
-    <h3>Radio Group with Validation in Iron Form</h3>
-    <vaadin-demo-snippet id="radio-group-demos-radio-group-with-iron-form">
-      <template preserve-content>
-        <iron-form id="test-form">
-          <form>
-            <vaadin-radio-group label="Complexity Level" required error-message="Please select an option">
-              <vaadin-radio-button name="complexity-one">1</vaadin-radio-button>
-              <vaadin-radio-button name="complexity-two">2</vaadin-radio-button>
-              <vaadin-radio-button name="complexity-three">3</vaadin-radio-button>
-              <vaadin-radio-button name="complexity-four">4</vaadin-radio-button>
-            </vaadin-radio-group>
-            <vaadin-button id="submit-button">Submit</vaadin-button>
-          </form>
-          <div id="iron-form-output"></div>
-        </iron-form>
-        <script>
-          window.addDemoReadyListener('#radio-group-demos-radio-group-with-iron-form', function(document) {
-            var testForm = document.getElementById('test-form');
-            var submitButton = document.getElementById('submit-button');
-
-            submitButton.addEventListener('click', function(event) {
-              testForm.submit();
-            });
-
-            testForm.addEventListener('iron-form-submit', function(event) {
-              this.querySelector('#iron-form-output').innerHTML = JSON.stringify(event.detail);
-            });
-          });
-        </script>
-      </template>
-    </vaadin-demo-snippet>
-
-    <h3>Radio Group with Custom Value Name in Iron Form</h3>
-    <vaadin-demo-snippet id="radio-group-demos-radio-group-with-iron-form-with-custom-value">
-      <template preserve-content>
-        <iron-form id="test-form-custom-value">
-          <form>
-            <vaadin-radio-group label="Complexity Level" required error-message="Please select an option">
-              <vaadin-radio-button name="complexity" value="1">1</vaadin-radio-button>
-              <vaadin-radio-button name="complexity" value="2">2</vaadin-radio-button>
-              <vaadin-radio-button name="complexity" value="3">3</vaadin-radio-button>
-              <vaadin-radio-button name="complexity" value="4">4</vaadin-radio-button>
-            </vaadin-radio-group>
-            <vaadin-button id="submit-button-custom-value">Submit</vaadin-button>
-          </form>
-          <div id="iron-form-output-custom-value"></div>
-        </iron-form>
-        <script>
-          window.addDemoReadyListener('#radio-group-demos-radio-group-with-iron-form-with-custom-value', function(document) {
-            var testForm = document.getElementById('test-form-custom-value');
-            var submitButton = document.getElementById('submit-button-custom-value');
-
-            submitButton.addEventListener('click', function(event) {
-              testForm.submit();
-            });
-
-            testForm.addEventListener('iron-form-submit', function(event) {
-              this.querySelector('#iron-form-output-custom-value').innerHTML = JSON.stringify(event.detail);
-            });
-          });
-        </script>
       </template>
     </vaadin-demo-snippet>
 

--- a/demo/radio-group-validation-demos.html
+++ b/demo/radio-group-validation-demos.html
@@ -1,0 +1,82 @@
+<dom-module id="radio-group-validation-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+      :host {
+        display: block;
+      }
+    </style>
+
+    <h3>Validation in Iron Form</h3>
+    <vaadin-demo-snippet id="radio-group-validation-demos-radio-group-with-iron-form">
+      <template preserve-content>
+        <iron-form id="test-form">
+          <form>
+            <vaadin-radio-group label="Complexity Level" required error-message="Please select an option">
+              <vaadin-radio-button name="complexity-one">1</vaadin-radio-button>
+              <vaadin-radio-button name="complexity-two">2</vaadin-radio-button>
+              <vaadin-radio-button name="complexity-three">3</vaadin-radio-button>
+              <vaadin-radio-button name="complexity-four">4</vaadin-radio-button>
+            </vaadin-radio-group>
+            <vaadin-button id="submit-button">Submit</vaadin-button>
+          </form>
+          <div id="iron-form-output"></div>
+        </iron-form>
+        <script>
+          window.addDemoReadyListener('#radio-group-validation-demos-radio-group-with-iron-form', function(document) {
+            var testForm = document.getElementById('test-form');
+            var submitButton = document.getElementById('submit-button');
+
+            submitButton.addEventListener('click', function(event) {
+              testForm.submit();
+            });
+
+            testForm.addEventListener('iron-form-submit', function(event) {
+              this.querySelector('#iron-form-output').innerHTML = JSON.stringify(event.detail);
+            });
+          });
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+
+    <h3>Custom Value Name in Iron Form</h3>
+    <vaadin-demo-snippet id="radio-group-validation-demos-radio-group-with-iron-form-with-custom-value">
+      <template preserve-content>
+        <iron-form id="test-form-custom-value">
+          <form>
+            <vaadin-radio-group label="Complexity Level" required error-message="Please select an option">
+              <vaadin-radio-button name="complexity" value="1">1</vaadin-radio-button>
+              <vaadin-radio-button name="complexity" value="2">2</vaadin-radio-button>
+              <vaadin-radio-button name="complexity" value="3">3</vaadin-radio-button>
+              <vaadin-radio-button name="complexity" value="4">4</vaadin-radio-button>
+            </vaadin-radio-group>
+            <vaadin-button id="submit-button-custom-value">Submit</vaadin-button>
+          </form>
+          <div id="iron-form-output-custom-value"></div>
+        </iron-form>
+        <script>
+          window.addDemoReadyListener('#radio-group-validation-demos-radio-group-with-iron-form-with-custom-value', function(document) {
+            var testForm = document.getElementById('test-form-custom-value');
+            var submitButton = document.getElementById('submit-button-custom-value');
+
+            submitButton.addEventListener('click', function(event) {
+              testForm.submit();
+            });
+
+            testForm.addEventListener('iron-form-submit', function(event) {
+              this.querySelector('#iron-form-output-custom-value').innerHTML = JSON.stringify(event.detail);
+            });
+          });
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+
+  </template>
+  <script>
+    class RadioGroupValidationDemos extends DemoReadyEventEmitter(RadioButtonDemo(Polymer.Element)) {
+      static get is() {
+        return 'radio-group-validation-demos';
+      }
+    }
+    customElements.define(RadioGroupValidationDemos.is, RadioGroupValidationDemos);
+  </script>
+</dom-module>


### PR DESCRIPTION
Connects to "Guidelines for component examples"
- Rename "Basic Examples" to "Radio Button"
- Created "Validation" demo page
- Renamed "Lumo Theme Variations" to "Theme Variants"
- Unified radio-button and radio-group demo example titles

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-radio-button/72)
<!-- Reviewable:end -->
