### PR TITLE
Prevent adding duplicate listeners on re-attaching

### DIFF
--- a/src/vaadin-radio-group.html
+++ b/src/vaadin-radio-group.html
@@ -169,13 +169,13 @@ This program is available under Apache License Version 2.0, available at https:/
           };
         }
 
-        /**
-         * @private
-         */
-        connectedCallback() {
-          super.connectedCallback();
-          this._observer = new Polymer.FlattenedNodesObserver(this, (info) => {
-            var checkedChangedListener = (e) => {
+        ready() {
+          super.ready();
+
+          this._addActiveListeners();
+
+          this._observer = new Polymer.FlattenedNodesObserver(this, info => {
+            const checkedChangedListener = e => {
               if (e.target.checked) {
                 this._changeSelectedButton(e.target);
               }
@@ -198,14 +198,7 @@ This program is available under Apache License Version 2.0, available at https:/
                 this.value = undefined;
               }
             });
-
           });
-        }
-
-        ready() {
-          super.ready();
-
-          this._addActiveListeners();
 
           if (this._radioButtons.length) {
             this._setFocusable(0);


### PR DESCRIPTION
Same as vaadin/vaadin-checkbox#116

Note: here it does not cause any issues, but we should avoid duplicate event listeners.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-radio-button/78)
<!-- Reviewable:end -->
