### PR TITLE
Set input element to be the focusElement

### DIFF
--- a/src/vaadin-radio-button.html
+++ b/src/vaadin-radio-button.html
@@ -203,7 +203,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         get focusElement() {
-          return this.shadowRoot.querySelector('label');
+          return this.shadowRoot.querySelector('input');
         }
 
         _preventDefault(e) {

--- a/test/vaadin-radio-button.html
+++ b/test/vaadin-radio-button.html
@@ -127,6 +127,10 @@
         MockInteractions.keyUpOn(vaadinRadioButton, 32);
         expect(vaadinRadioButton.hasAttribute('active')).to.be.false;
       });
+
+      it('should have input as focusElement', () => {
+        expect(vaadinRadioButton.focusElement).to.be.eql(nativeRadio);
+      });
     });
 
     describe('iron-form-radio-button', () => {


### PR DESCRIPTION
Connected to #77.

Issue occurs because the FF forwards the focus natively to its control element when `.focus` is called.
So we are getting into the loop in `control-state-mixin` of moving focus between `label` and `input`.
`_cycleTab` in overlay getting the incorrect focused `index` and cannot move the focus to the next element. 

I have tried to implement the focus test here, but it seems to be impossible, so I am checking the behaviour in `overlay`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-radio-button/79)
<!-- Reviewable:end -->
