### PR TITLE
Workaround IE11 jumpiness issue

### DIFF
--- a/theme/lumo/vaadin-radio-button-styles.html
+++ b/theme/lumo/vaadin-radio-button-styles.html
@@ -27,6 +27,7 @@
         pointer-events: none;
         will-change: transform;
         line-height: 1.2;
+        transform: translateZ(0); /* Workaround IE11 jumpiness */
       }
 
       /* Used for activation "halo" */


### PR DESCRIPTION
Fixes #93 

Still not sure about the reason, but that helps as well as `overflow: hidden`

Note: can be reviewed and confirmed using `vaadin-notification` sampler demo mentioned in the issue. With the suggested fix, no space appears below the group compared to GIF reproduction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-radio-button/98)
<!-- Reviewable:end -->
