### PR TITLE
docs(api): update name property to fix JSDoc issue

### DIFF
--- a/src/vaadin-radio-button.html
+++ b/src/vaadin-radio-button.html
@@ -128,24 +128,18 @@ This program is available under Apache License Version 2.0, available at https:/
             },
 
             /**
+             * Name of the element.
+             */
+            name: String,
+
+            /**
              * The value for this element.
              */
             value: {
               type: String,
               value: 'on'
             }
-
           };
-        }
-
-        constructor() {
-          super();
-
-          /**
-           * @type {string}
-           * Name of the element.
-           */
-          this.name;
         }
 
         get name() {


### PR DESCRIPTION
Fixes #95 

This partially reverts the original fix from af64a82b43693dd655bebe85a99cd2bb2165bee8

Looks like using properties block still allows to also have custom getter and setter.
Let's see if all the tests pass and if so, then use this approach.