### PR TITLE
fix: ensure change event on mouseup is fired

### DIFF
--- a/src/vaadin-radio-button.html
+++ b/src/vaadin-radio-button.html
@@ -224,7 +224,7 @@ This program is available under Apache License Version 2.0, available at https:/
             this.removeAttribute('active');
 
             if (!this.checked && !this.disabled) {
-              this.checked = true;
+              this.click();
             }
           });
 

--- a/test/vaadin-radio-button.html
+++ b/test/vaadin-radio-button.html
@@ -175,6 +175,15 @@
           expect(spy).to.be.calledOnce;
         });
 
+        it('should fire on down / up event', () => {
+          const spy = sinon.spy();
+          vaadinRadioButton.addEventListener('change', spy);
+
+          down(vaadinRadioButton);
+          up(vaadinRadioButton);
+          expect(spy).to.be.calledOnce;
+        });
+
         it('should fire on space keyup', () => {
           const spy = sinon.spy();
           vaadinRadioButton.addEventListener('change', spy);


### PR DESCRIPTION
Fixes #121 

Note: now when this is fixed, there is another problem: user can listen to `change` event for `radio-group` and get bubbling event from `radio-button` before the radio group value is updated.

I'm wondering if we should handle that by catching that event with `stopImmediatePropagation` and then re-dispatching a proper `change` event from the radio group itself 🤔 