### PR TITLE
fix: re-dispatch change event properly

### DIFF
--- a/demo/radio-button-basic-demos.html
+++ b/demo/radio-button-basic-demos.html
@@ -78,12 +78,12 @@
           <vaadin-radio-button value="two">Option two</vaadin-radio-button>
           <vaadin-radio-button value="three">Option three</vaadin-radio-button>
         </vaadin-radio-group>
-        <div id="output">Selected value:</div>
+        <div>Selected value: <span id="output"></span></div>
         <script>
           window.addDemoReadyListener('#value-change-event', function(document) {
             const radioButtonGroup = document.querySelector('vaadin-radio-group');
             const output = document.querySelector('#output');
-            radioButtonGroup.addEventListener('value-changed', function(event) {
+            radioButtonGroup.addEventListener('change', function(event) {
               output.textContent = radioButtonGroup.value;
             });
           });

--- a/src/vaadin-radio-group.html
+++ b/src/vaadin-radio-group.html
@@ -182,10 +182,18 @@ This program is available under Apache License Version 2.0, available at https:/
 
           this._addListeners();
 
+          this.addEventListener('change', e => {
+            if (e.composedPath()[0] instanceof Vaadin.RadioButtonElement) {
+              e.stopImmediatePropagation();
+              // store reference to the original event
+              this.__inputChange = e.detail.sourceEvent;
+            }
+          });
+
           this._observer = new Polymer.FlattenedNodesObserver(this, info => {
             const checkedChangedListener = e => {
               if (e.target.checked) {
-                this._changeSelectedButton(e.target);
+                this._changeSelectedButton(e.target, Boolean(this.__inputChange));
               }
             };
 
@@ -371,6 +379,18 @@ This program is available under Apache License Version 2.0, available at https:/
           this.validate();
           this.readonly && this._updateDisableButtons();
           button && this._setFocusable(this._radioButtons.indexOf(button));
+
+          if (fireChangeEvent) {
+            const { bubbles, cancelable } = this.__inputChange;
+            this.__inputChange = null;
+            this.dispatchEvent(new CustomEvent('change', {
+              detail: {
+                sourceEvent: this.__inputChange
+              },
+              bubbles,
+              cancelable
+            }));
+          }
         }
 
         _valueChanged(newV, oldV) {


### PR DESCRIPTION
@hongduc-phan please continue from here and write tests.

- test that `value` on the `vaadin-radio-group` is updated at the time when `change` is fired
- test that only events from `vaadin-radio-button` get stopped: add normal `<input>` inside `<vaadin-radio-group>` and try to dispatch `change` event on it manually
- test that change event contains `sourceEvent` from the internal `<input type="radio">`