### PR TITLE
fix by changing from 2 ways binding to 1 way binding of checked prope…

### DIFF
--- a/src/vaadin-radio-button.html
+++ b/src/vaadin-radio-button.html
@@ -50,7 +50,7 @@ This program is available under Apache License Version 2.0, available at https:/
       <span part="radio">
         <input
           type="radio"
-          checked="{{checked::change}}"
+          checked="[[checked]]"
           disabled$="[[disabled]]"
           role="presentation"
           on-change="_onChange"
@@ -260,6 +260,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _onChange(e) {
+          this.checked = e.target.checked;
           // In the Shadow DOM, the `change` event is not leaked into the
           // ancestor tree, so we must do this manually.
           const changeEvent = new CustomEvent('change', {

--- a/src/vaadin-radio-group.html
+++ b/src/vaadin-radio-group.html
@@ -179,7 +179,6 @@ This program is available under Apache License Version 2.0, available at https:/
 
         ready() {
           super.ready();
-    
           this._addListeners();
           this._observer = new Polymer.FlattenedNodesObserver(this, info => {
             const checkedChangedListener = e => {
@@ -258,7 +257,6 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _addListeners() {
-    
           this.addEventListener('keydown', e => {
             this.isKeyDown = true;
             // if e.target is vaadin-radio-group then assign to checkedRadioButton currently checked radio button
@@ -277,7 +275,6 @@ This program is available under Apache License Version 2.0, available at https:/
               e.preventDefault();
               this._selectIncButton(!horizontalRTL, checkedRadioButton);
             }
-            this._checkKeyDown = true;
           });
 
           this.addEventListener('focusin', () => this._setFocused(this._containsFocus()));

--- a/src/vaadin-radio-group.html
+++ b/src/vaadin-radio-group.html
@@ -260,7 +260,6 @@ This program is available under Apache License Version 2.0, available at https:/
 
         _addListeners() {
           this.addEventListener('keydown', e => {
-            this._isKeyDown = true;
             // if e.target is vaadin-radio-group then assign to checkedRadioButton currently checked radio button
             var checkedRadioButton = (e.target == this) ? this._checkedButton : e.target;
             const horizontalRTL = this.getAttribute('dir') === 'rtl'
@@ -347,12 +346,16 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _changeSelectedButton(button, fireChangeEvent) {
-          if (this._checkedButton === button && !this._isKeyDown) {
+          if (this._checkedButton === button) {
             return;
           }
 
           this._checkedButton = button;
 
+          if (this._checkedButton) {
+            this.value = this._checkedButton.value;
+          }
+    
           this._radioButtons.forEach(button => {
             if (button === this._checkedButton) {
               if (fireChangeEvent) {
@@ -365,14 +368,9 @@ This program is available under Apache License Version 2.0, available at https:/
             }
           });
 
-          if (this._checkedButton) {
-            this.value = this._checkedButton.value;
-          }
-
           this.validate();
           this.readonly && this._updateDisableButtons();
           button && this._setFocusable(this._radioButtons.indexOf(button));
-          this._isKeyDown = false;
         }
 
         _valueChanged(newV, oldV) {

--- a/src/vaadin-radio-group.html
+++ b/src/vaadin-radio-group.html
@@ -179,7 +179,9 @@ This program is available under Apache License Version 2.0, available at https:/
 
         ready() {
           super.ready();
+
           this._addListeners();
+
           this._observer = new Polymer.FlattenedNodesObserver(this, info => {
             const checkedChangedListener = e => {
               if (e.target.checked) {

--- a/src/vaadin-radio-group.html
+++ b/src/vaadin-radio-group.html
@@ -258,7 +258,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         _addListeners() {
           this.addEventListener('keydown', e => {
-            this.isKeyDown = true;
+            this._isKeyDown = true;
             // if e.target is vaadin-radio-group then assign to checkedRadioButton currently checked radio button
             var checkedRadioButton = (e.target == this) ? this._checkedButton : e.target;
             const horizontalRTL = this.getAttribute('dir') === 'rtl'
@@ -345,7 +345,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _changeSelectedButton(button, fireChangeEvent) {
-          if (this._checkedButton === button && !this.isKeyDown) {
+          if (this._checkedButton === button && !this._isKeyDown) {
             return;
           }
 
@@ -370,7 +370,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.validate();
           this.readonly && this._updateDisableButtons();
           button && this._setFocusable(this._radioButtons.indexOf(button));
-          this.isKeyDown = false;
+          this._isKeyDown = false;
         }
 
         _valueChanged(newV, oldV) {

--- a/src/vaadin-radio-group.html
+++ b/src/vaadin-radio-group.html
@@ -179,9 +179,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
         ready() {
           super.ready();
-
+    
           this._addListeners();
-
           this._observer = new Polymer.FlattenedNodesObserver(this, info => {
             const checkedChangedListener = e => {
               if (e.target.checked) {
@@ -259,7 +258,9 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _addListeners() {
+    
           this.addEventListener('keydown', e => {
+            this.isKeyDown = true;
             // if e.target is vaadin-radio-group then assign to checkedRadioButton currently checked radio button
             var checkedRadioButton = (e.target == this) ? this._checkedButton : e.target;
             const horizontalRTL = this.getAttribute('dir') === 'rtl'
@@ -276,6 +277,7 @@ This program is available under Apache License Version 2.0, available at https:/
               e.preventDefault();
               this._selectIncButton(!horizontalRTL, checkedRadioButton);
             }
+            this._checkKeyDown = true;
           });
 
           this.addEventListener('focusin', () => this._setFocused(this._containsFocus()));
@@ -346,7 +348,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _changeSelectedButton(button, fireChangeEvent) {
-          if (this._checkedButton === button) {
+          if (this._checkedButton === button && !this.isKeyDown) {
             return;
           }
 
@@ -371,6 +373,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.validate();
           this.readonly && this._updateDisableButtons();
           button && this._setFocusable(this._radioButtons.indexOf(button));
+          this.isKeyDown = false;
         }
 
         _valueChanged(newV, oldV) {

--- a/test/vaadin-radio-group.html
+++ b/test/vaadin-radio-group.html
@@ -548,6 +548,47 @@
 
           expect(spy).to.not.be.called;
         });
+    
+        it('should value on the vaadin-radio-group is updated at the time when change is fired by clicking mouse', done => {
+          // Mouse
+          vaadinRadioButtonGroup.addEventListener('change', e => {
+            expect(vaadinRadioButtonGroup.value).to.equal(vaadinRadioButtonList[2].value);
+            done();
+          });
+          vaadinRadioButtonList[2].click();
+        });
+
+        it('should change event on radio-group includes updated value after clicking mouse', done => {
+          vaadinRadioButtonGroup.addEventListener('change', e => {
+            expect(e.target.textContent).to.equal(vaadinRadioButtonList[2].textContent);
+            expect(e.currentTarget.value).to.equal(vaadinRadioButtonList[2].value);
+            done();
+          });
+          vaadinRadioButtonList[2].click();
+        });
+
+        it('should value on the vaadin-radio-group is updated at the time when change is fired by pressing down', (done) => {
+          vaadinRadioButtonList[1].focus();
+          vaadinRadioButtonList[1].checked = true;
+          expect(vaadinRadioButtonGroup.value).to.equal(vaadinRadioButtonList[1].value);
+          // Key down
+          vaadinRadioButtonGroup.addEventListener('change', e => {
+            expect(vaadinRadioButtonGroup.value).to.equal(vaadinRadioButtonList[0].value);
+            done();
+          });
+          MockInteractions.keyDownOn(vaadinRadioButtonGroup, 37);
+        });
+
+        it('should change event on radio-group includes updated value after pressing key down', done => {
+          vaadinRadioButtonList[1].focus();
+          vaadinRadioButtonList[1].checked = true;
+          vaadinRadioButtonGroup.addEventListener('change', e => {
+            expect(e.target.textContent).to.equal(vaadinRadioButtonList[0].textContent);
+            expect(e.currentTarget.value).to.equal(vaadinRadioButtonList[0].value);
+            done();
+          });
+          MockInteractions.keyDownOn(vaadinRadioButtonGroup, 37);
+        });
       });
     });
 
@@ -613,30 +654,12 @@
     });
 
     describe('vaadin-radio-group wrapping', () => {
-      let vaadinRadioButtonGroup, vaadinRadioButtonList;
+      let vaadinRadioButtonGroup;
 
       beforeEach((done) => {
         vaadinRadioButtonGroup = fixture('wrapping');
-        vaadinRadioButtonList = vaadinRadioButtonGroup.querySelectorAll('vaadin-radio-button');
         vaadinRadioButtonGroup._observer.flush();
         animationFrameFlush(done);
-      });
-
-      it('should value on the vaadin-radio-group is updated at the time when change is fired', done => {
-        vaadinRadioButtonGroup.addEventListener('change', e => {
-          expect(vaadinRadioButtonGroup.value).to.equal(vaadinRadioButtonList[2].value);
-          done();
-        });
-        vaadinRadioButtonList[2].click();
-      });
-
-      it('should change event on radio-group includes updated value', done => {
-        vaadinRadioButtonGroup.addEventListener('change', e => {
-          expect(e.target.textContent).to.equal(vaadinRadioButtonList[2].textContent);
-          expect(e.currentTarget.value).to.equal(vaadinRadioButtonList[2].value);
-          done();
-        });
-        vaadinRadioButtonList[2].click();
       });
     
       it('should not overflow horizontally', () => {

--- a/test/vaadin-radio-group.html
+++ b/test/vaadin-radio-group.html
@@ -497,6 +497,7 @@
       });
 
       describe('change event', () => {
+
         it('should fire on right/down', () => {
           vaadinRadioButtonList[1].focus();
           vaadinRadioButtonList[1].checked = true;
@@ -613,14 +614,24 @@
     });
 
     describe('vaadin-radio-group wrapping', () => {
-      let vaadinRadioButtonGroup;
+      let vaadinRadioButtonGroup, vaadinRadioButtonList;
 
       beforeEach((done) => {
         vaadinRadioButtonGroup = fixture('wrapping');
+        vaadinRadioButtonList = vaadinRadioButtonGroup.querySelectorAll('vaadin-radio-button');
         vaadinRadioButtonGroup._observer.flush();
         animationFrameFlush(done);
       });
 
+      it('should value on the vaadin-radio-group is updated at the time when change is fired', () => {
+        vaadinRadioButtonGroup.addEventListener('change', e => {
+          expect(vaadinRadioButtonGroup.value).to.equal(vaadinRadioButtonList[2].value);
+          expect(e.target.textContent).to.equal(vaadinRadioButtonList[2].textContent);
+          expect(e.currentTarget.value).to.equal(vaadinRadioButtonList[2].value);
+        });
+        vaadinRadioButtonList[2].click();
+      });
+    
       it('should not overflow horizontally', () => {
         const parentWidth = vaadinRadioButtonGroup.parentElement.offsetWidth;
         expect(vaadinRadioButtonGroup.offsetWidth).to.be.lte(parentWidth);

--- a/test/vaadin-radio-group.html
+++ b/test/vaadin-radio-group.html
@@ -549,7 +549,7 @@
           expect(spy).to.not.be.called;
         });
     
-        it('should value on the vaadin-radio-group is updated on click at the time when change event is fired', done => {
+        it('should value on the vaadin-radio-group is updated at the time when change event is fired after click selection', done => {
           // Mouse event
           vaadinRadioButtonGroup.addEventListener('change', e => {
             expect(vaadinRadioButtonGroup.value).to.equal(vaadinRadioButtonList[2].value);
@@ -558,7 +558,7 @@
           vaadinRadioButtonList[2].click();
         });
 
-        it('should change event on radio-group includes updated value on click', done => {
+        it('should include updated value on change event on radio-group after click selection', done => {
           vaadinRadioButtonGroup.addEventListener('change', e => {
             expect(e.target).to.equal(vaadinRadioButtonList[2]);
             expect(e.currentTarget.value).to.equal(vaadinRadioButtonList[2].value);
@@ -567,7 +567,7 @@
           vaadinRadioButtonList[2].click();
         });
 
-        it('should value on the vaadin-radio-group is updated on keyboard selection at the time when change event is fired', done => {
+        it('should value on the vaadin-radio-group is updated at the time when change event is fired after keyboard selection', done => {
           vaadinRadioButtonList[1].focus();
           vaadinRadioButtonList[1].checked = true;
           // keyboard selection
@@ -578,7 +578,7 @@
           MockInteractions.keyDownOn(vaadinRadioButtonGroup, 37);
         });
 
-        it('should change event on radio-group includes updated value on keyboard selection', done => {
+        it('should include updated value on change event on radio-group after keyboard selection', done => {
           vaadinRadioButtonList[1].focus();
           vaadinRadioButtonList[1].checked = true;
           vaadinRadioButtonGroup.addEventListener('change', e => {

--- a/test/vaadin-radio-group.html
+++ b/test/vaadin-radio-group.html
@@ -661,7 +661,7 @@
         vaadinRadioButtonGroup._observer.flush();
         animationFrameFlush(done);
       });
-    
+
       it('should not overflow horizontally', () => {
         const parentWidth = vaadinRadioButtonGroup.parentElement.offsetWidth;
         expect(vaadinRadioButtonGroup.offsetWidth).to.be.lte(parentWidth);

--- a/test/vaadin-radio-group.html
+++ b/test/vaadin-radio-group.html
@@ -549,8 +549,8 @@
           expect(spy).to.not.be.called;
         });
     
-        it('should value on the vaadin-radio-group is updated at the time when change is fired by clicking mouse', done => {
-          // Mouse
+        it('should value on the vaadin-radio-group is updated on click at the time when change event is fired', done => {
+          // Mouse event
           vaadinRadioButtonGroup.addEventListener('change', e => {
             expect(vaadinRadioButtonGroup.value).to.equal(vaadinRadioButtonList[2].value);
             done();
@@ -558,20 +558,19 @@
           vaadinRadioButtonList[2].click();
         });
 
-        it('should change event on radio-group includes updated value after clicking mouse', done => {
+        it('should change event on radio-group includes updated value on click', done => {
           vaadinRadioButtonGroup.addEventListener('change', e => {
-            expect(e.target.textContent).to.equal(vaadinRadioButtonList[2].textContent);
+            expect(e.target).to.equal(vaadinRadioButtonList[2]);
             expect(e.currentTarget.value).to.equal(vaadinRadioButtonList[2].value);
             done();
           });
           vaadinRadioButtonList[2].click();
         });
 
-        it('should value on the vaadin-radio-group is updated at the time when change is fired by pressing down', (done) => {
+        it('should value on the vaadin-radio-group is updated on keyboard selection at the time when change event is fired', done => {
           vaadinRadioButtonList[1].focus();
           vaadinRadioButtonList[1].checked = true;
-          expect(vaadinRadioButtonGroup.value).to.equal(vaadinRadioButtonList[1].value);
-          // Key down
+          // keyboard selection
           vaadinRadioButtonGroup.addEventListener('change', e => {
             expect(vaadinRadioButtonGroup.value).to.equal(vaadinRadioButtonList[0].value);
             done();
@@ -579,11 +578,11 @@
           MockInteractions.keyDownOn(vaadinRadioButtonGroup, 37);
         });
 
-        it('should change event on radio-group includes updated value after pressing key down', done => {
+        it('should change event on radio-group includes updated value on keyboard selection', done => {
           vaadinRadioButtonList[1].focus();
           vaadinRadioButtonList[1].checked = true;
           vaadinRadioButtonGroup.addEventListener('change', e => {
-            expect(e.target.textContent).to.equal(vaadinRadioButtonList[0].textContent);
+            expect(e.target).to.equal(vaadinRadioButtonList[0]);
             expect(e.currentTarget.value).to.equal(vaadinRadioButtonList[0].value);
             done();
           });

--- a/test/vaadin-radio-group.html
+++ b/test/vaadin-radio-group.html
@@ -626,6 +626,12 @@
       it('should value on the vaadin-radio-group is updated at the time when change is fired', () => {
         vaadinRadioButtonGroup.addEventListener('change', e => {
           expect(vaadinRadioButtonGroup.value).to.equal(vaadinRadioButtonList[2].value);
+        });
+        vaadinRadioButtonList[2].click();
+      });
+
+      it('should change event on radio-group includes updated value', () => {
+        vaadinRadioButtonGroup.addEventListener('change', e => {
           expect(e.target.textContent).to.equal(vaadinRadioButtonList[2].textContent);
           expect(e.currentTarget.value).to.equal(vaadinRadioButtonList[2].value);
         });

--- a/test/vaadin-radio-group.html
+++ b/test/vaadin-radio-group.html
@@ -497,7 +497,6 @@
       });
 
       describe('change event', () => {
-
         it('should fire on right/down', () => {
           vaadinRadioButtonList[1].focus();
           vaadinRadioButtonList[1].checked = true;
@@ -623,17 +622,19 @@
         animationFrameFlush(done);
       });
 
-      it('should value on the vaadin-radio-group is updated at the time when change is fired', () => {
+      it('should value on the vaadin-radio-group is updated at the time when change is fired', done => {
         vaadinRadioButtonGroup.addEventListener('change', e => {
           expect(vaadinRadioButtonGroup.value).to.equal(vaadinRadioButtonList[2].value);
+          done();
         });
         vaadinRadioButtonList[2].click();
       });
 
-      it('should change event on radio-group includes updated value', () => {
+      it('should change event on radio-group includes updated value', done => {
         vaadinRadioButtonGroup.addEventListener('change', e => {
           expect(e.target.textContent).to.equal(vaadinRadioButtonList[2].textContent);
           expect(e.currentTarget.value).to.equal(vaadinRadioButtonList[2].value);
+          done();
         });
         vaadinRadioButtonList[2].click();
       });


### PR DESCRIPTION
Fixes by changing from 2 ways binding to 1 way binding of checked property on radio-button, because after trigger _onChange on radio-button, the checked prop is updated and then it will trigger checked-changed event listener on radio-group and update its value on radio-group, and change event on radio-group is dispatched that includes updated value.
In the keyboard selection case,  changed the order of `checks the checkbox, causing the change event` and `update value of radio-group`.

Fixes #125 