### PR TITLE
[1.2] fix: functionality for iOS 12 and 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - node_modules
 
 addons:
-  firefox: "66.0"
+  firefox: latest
   chrome: stable
 
 jobs:
@@ -22,12 +22,12 @@ jobs:
     - if: type = pull_request
       env: POLYMER=2
       addons:
-        firefox: "66.0"
+        firefox: latest
         chrome: stable
     - if: type = pull_request
       env: POLYMER=3
       addons:
-        firefox: "66.0"
+        firefox: latest
         chrome: stable
     - if: type = cron
       env: TEST_SUITE=unit_tests POLYMER=2

--- a/src/vaadin-radio-button.html
+++ b/src/vaadin-radio-button.html
@@ -224,6 +224,10 @@ This program is available under Apache License Version 2.0, available at https:/
             this.removeAttribute('active');
 
             if (!this.checked && !this.disabled) {
+              // If you change this block, please test manually that radio-button and
+              // radio-group still works ok on iOS 12/13 and up as it may cause
+              // an issue that is not possible to test programmatically.
+              // See: https://github.com/vaadin/vaadin-radio-button/issues/140
               this.click();
             }
           });
@@ -250,7 +254,13 @@ This program is available under Apache License Version 2.0, available at https:/
          * @protected
          */
         click() {
-          this.shadowRoot.querySelector('input').click();
+          // If you change this block, please test manually that radio-button and
+          // radio-group still works ok on iOS 12/13 and up as it may cause
+          // an issue that is not possible to test programmatically.
+          // See: https://github.com/vaadin/vaadin-radio-button/issues/140
+          if (!this.disabled) {
+            this.shadowRoot.querySelector('input').dispatchEvent(new MouseEvent('click'));
+          }
         }
 
         /** @protected */


### PR DESCRIPTION
Clean cherry-pick of https://github.com/vaadin/vaadin-radio-button/pull/143 for 1.2 branch. Manually tested on iOS 12 and 13 and confirmed working.

Fixes #140.