### PR TITLE
feat: prepare for TS defs generation [skip ci]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,22 +29,19 @@
   ],
   "dependencies": {
     "polymer": "^2.0.0",
-    "vaadin-control-state-mixin": "vaadin/vaadin-control-state-mixin#^2.1.1",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.1",
+    "vaadin-control-state-mixin": "vaadin/vaadin-control-state-mixin#^2.2.1",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.6.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.3.2",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.0"
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",
     "iron-form": "^2.0.0",
     "iron-test-helpers": "^2.0.0",
-    "vaadin-button": "vaadin/vaadin-button#^2.3.0",
+    "vaadin-button": "vaadin/vaadin-button#^2.4.0-alpha1",
     "webcomponentsjs": "^1.0.0",
     "web-component-tester": "^6.1.5",
     "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^3.1.0-alpha1"
-  },
-  "resolutions": {
-    "vaadin-element-mixin": "^2.0.0"
   }
 }

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,9 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ]
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,12 @@
+module.exports = {
+  files: [
+    'vaadin-radio-button.js',
+    'vaadin-radio-group.js'
+  ],
+  from: [
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
     "src",
     "theme"

--- a/src/vaadin-radio-button.html
+++ b/src/vaadin-radio-button.html
@@ -154,6 +154,9 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         /**
+         * @param {string} name
+         * @param {?string} oldValue
+         * @param {?string} newValue
          * @protected
          */
         attributeChangedCallback(prop, oldVal, newVal) {
@@ -175,7 +178,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
-
+        /** @protected */
         ready() {
           super.ready();
 

--- a/src/vaadin-radio-button.html
+++ b/src/vaadin-radio-button.html
@@ -154,9 +154,9 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         /**
-         * @param {string} name
-         * @param {?string} oldValue
-         * @param {?string} newValue
+         * @param {string} prop
+         * @param {?string} oldVal
+         * @param {?string} newVal
          * @protected
          */
         attributeChangedCallback(prop, oldVal, newVal) {

--- a/src/vaadin-radio-button.html
+++ b/src/vaadin-radio-button.html
@@ -119,6 +119,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return {
             /**
              * True if the radio button is checked.
+             * @type {boolean}
              */
             checked: {
               type: Boolean,
@@ -135,6 +136,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * The value for this element.
+             * @type {string}
              */
             value: {
               type: String,
@@ -192,6 +194,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this._updateLabelAttribute();
         }
 
+        /** @private */
         _updateLabelAttribute() {
           const label = this.shadowRoot.querySelector('[part~="label"]');
           const assignedNodes = label.firstElementChild.assignedNodes();
@@ -202,6 +205,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _isAssignedNodesEmpty(nodes) {
           // The assigned nodes considered to be empty if there is no slotted content or only one empty text node
           return nodes.length === 0 ||
@@ -210,10 +214,12 @@ This program is available under Apache License Version 2.0, available at https:/
               && nodes[0].textContent.trim() === '');
         }
 
+        /** @private */
         _checkedChanged(checked) {
           this.setAttribute('aria-checked', checked);
         }
 
+        /** @private */
         _addListeners() {
           this._addEventListenerToNode(this, 'down', (e) => {
             if (!this.disabled) {
@@ -264,11 +270,15 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
-        /** @protected */
+        /**
+         * @return {!HTMLInputElement}
+         * @protected
+         */
         get focusElement() {
           return this.shadowRoot.querySelector('input');
         }
 
+        /** @private */
         _onChange(e) {
           this.checked = e.target.checked;
           // In the Shadow DOM, the `change` event is not leaked into the

--- a/src/vaadin-radio-group.html
+++ b/src/vaadin-radio-group.html
@@ -95,6 +95,7 @@ This program is available under Apache License Version 2.0, available at https:/
        *
        * @memberof Vaadin
        * @mixes Vaadin.ThemableMixin
+       * @mixes Vaadin.DirMixin
        * @element vaadin-radio-group
        * @demo demo/index.html
        */
@@ -125,6 +126,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * This property is set to true when the value is invalid.
+             * @type {boolean}
              */
             invalid: {
               type: Boolean,
@@ -149,16 +151,19 @@ This program is available under Apache License Version 2.0, available at https:/
               value: ''
             },
 
+            /** @private */
             _errorId: {
               type: String
             },
 
+            /** @private */
             _checkedButton: {
               type: Object
             },
 
             /**
              * String used for the label element.
+             * @type {string}
              */
             label: {
               type: String,
@@ -218,10 +223,15 @@ This program is available under Apache License Version 2.0, available at https:/
           this._errorId = `${this.constructor.is}-error-${uniqueId}`;
         }
 
+        /** @private */
         get _radioButtons() {
           return this._filterRadioButtons(this.querySelectorAll('*'));
         }
 
+        /**
+         * @param {boolean} focused
+         * @protected
+         */
         _setFocused(focused) {
           if (focused) {
             this.setAttribute('focused', '');
@@ -230,16 +240,19 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _filterRadioButtons(nodes) {
           return Array.from(nodes)
             .filter(child => child instanceof Vaadin.RadioButtonElement);
         }
 
+        /** @private */
         _disabledChanged(disabled) {
           this.setAttribute('aria-disabled', disabled);
           this._updateDisableButtons();
         }
 
+        /** @private */
         _updateDisableButtons() {
           this._radioButtons.forEach(button => {
             if (this.disabled) {
@@ -254,10 +267,12 @@ This program is available under Apache License Version 2.0, available at https:/
           });
         }
 
+        /** @private */
         _readonlyChanged(newV, oldV) {
           (newV || oldV) && this._updateDisableButtons();
         }
 
+        /** @private */
         _addListeners() {
           this.addEventListener('keydown', e => {
             // if e.target is vaadin-radio-group then assign to checkedRadioButton currently checked radio button
@@ -288,6 +303,11 @@ This program is available under Apache License Version 2.0, available at https:/
           });
         }
 
+        /**
+         * @param {boolean} next
+         * @param {!RadioButtonElement} checkedRadioButton
+         * @protected
+         */
         _selectIncButton(next, checkedRadioButton) {
           if (next) {
             this._selectNextButton(checkedRadioButton);
@@ -296,6 +316,11 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /**
+         * @param {!RadioButtonElement} element
+         * @param {boolean=} setFocusRing
+         * @protected
+         */
         _selectButton(element, setFocusRing) {
           if (this._containsFocus()) {
             element.focus();
@@ -306,6 +331,10 @@ This program is available under Apache License Version 2.0, available at https:/
           this._changeSelectedButton(element, setFocusRing);
         }
 
+        /**
+         * @return {boolean}
+         * @protected
+         */
         _containsFocus() {
           const root = this.getRootNode();
           // Safari 9 needs polyfilled `_activeElement` to return correct node
@@ -313,10 +342,18 @@ This program is available under Apache License Version 2.0, available at https:/
           return this.contains(activeElement);
         }
 
+        /**
+         * @return {boolean}
+         * @protected
+         */
         _hasEnabledButtons() {
           return !this._radioButtons.every((button) => button.disabled);
         }
 
+        /**
+         * @param {!RadioButtonElement} element
+         * @protected
+         */
         _selectNextButton(element) {
           if (!this._hasEnabledButtons()) {
             return;
@@ -331,6 +368,10 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /**
+         * @param {!RadioButtonElement} element
+         * @protected
+         */
         _selectPreviousButton(element) {
           if (!this._hasEnabledButtons()) {
             return;
@@ -345,6 +386,11 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /**
+         * @param {RadioButtonElement} button
+         * @param {boolean=} fireChangeEvent
+         * @protected
+         */
         _changeSelectedButton(button, fireChangeEvent) {
           if (this._checkedButton === button) {
             return;
@@ -355,7 +401,7 @@ This program is available under Apache License Version 2.0, available at https:/
           if (this._checkedButton) {
             this.value = this._checkedButton.value;
           }
-    
+
           this._radioButtons.forEach(button => {
             if (button === this._checkedButton) {
               if (fireChangeEvent) {
@@ -373,6 +419,7 @@ This program is available under Apache License Version 2.0, available at https:/
           button && this._setFocusable(this._radioButtons.indexOf(button));
         }
 
+        /** @private */
         _valueChanged(newV, oldV) {
           if (oldV && (newV === '' || newV === null || newV === undefined)) {
             this._changeSelectedButton(null);
@@ -404,17 +451,22 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * Returns true if the current input value satisfies all constraints (if any)
-         * @returns {boolean}
+         * @return {boolean}
          */
         checkValidity() {
           return !this.required || !!this.value;
         }
 
+        /**
+         * @param {number} idx
+         * @protected
+         */
         _setFocusable(idx) {
           const items = this._radioButtons;
           items.forEach(e => e.tabindex = e === items[idx] ? 0 : -1);
         }
 
+        /** @private */
         _labelChanged(label) {
           if (label) {
             this.setAttribute('has-label', '');
@@ -423,10 +475,12 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _getActiveErrorId(invalid, errorMessage, errorId) {
           return errorMessage && invalid ? errorId : undefined;
         }
 
+        /** @private */
         _getErrorMessageAriaHidden(invalid, errorMessage, errorId) {
           return (!this._getActiveErrorId(invalid, errorMessage, errorId)).toString();
         }

--- a/src/vaadin-radio-group.html
+++ b/src/vaadin-radio-group.html
@@ -145,6 +145,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Error to show when the input value is invalid.
+             * @type {string}
              */
             errorMessage: {
               type: String,
@@ -182,6 +183,7 @@ This program is available under Apache License Version 2.0, available at https:/
           };
         }
 
+        /** @protected */
         ready() {
           super.ready();
 


### PR DESCRIPTION
Fixes #150 

Generated TS definitions files look like this:

### `vaadin-radio-button.d.ts`

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {GestureEventListeners} from '@polymer/polymer/lib/mixins/gesture-event-listeners.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {ControlStateMixin} from '@vaadin/vaadin-control-state-mixin/vaadin-control-state-mixin.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

declare class RadioButtonElement extends
  ElementMixin(
  ControlStateMixin(
  ThemableMixin(
  GestureEventListeners(
  PolymerElement)))) {
  readonly focusElement: HTMLInputElement;
  name: string|null|undefined;
  checked: boolean;
  value: string;
  ready(): void;
  attributeChangedCallback(prop: any, oldVal: any, newVal: any): void;
  click(): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-radio-button": RadioButtonElement;
  }
}

export {RadioButtonElement};
```

### `vaadin-radio-group.d.ts`

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {FlattenedNodesObserver} from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {DirMixin} from '@vaadin/vaadin-element-mixin/vaadin-dir-mixin.js';

import {RadioButtonElement} from './vaadin-radio-button.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

declare class RadioGroupElement extends
  ThemableMixin(
  DirMixin(
  PolymerElement)) {
  disabled: boolean|null|undefined;
  readonly: boolean|null|undefined;
  invalid: boolean;
  required: boolean|null|undefined;
  errorMessage: string|null|undefined;
  label: string;
  value: string|null|undefined;
  ready(): void;
  _setFocused(focused: boolean): void;
  _selectIncButton(next: boolean, checkedRadioButton: RadioButtonElement): void;
  _selectButton(element: RadioButtonElement, setFocusRing?: boolean): void;
  _containsFocus(): boolean;
  _hasEnabledButtons(): boolean;
  _selectNextButton(element: RadioButtonElement): void;
  _selectPreviousButton(element: RadioButtonElement): void;
  _changeSelectedButton(button: RadioButtonElement|null, fireChangeEvent?: boolean): void;
  validate(): boolean;
  checkValidity(): boolean;
  _setFocusable(idx: number): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-radio-group": RadioGroupElement;
  }
}

export {RadioGroupElement};
```