### PR TITLE
docs: add JSDoc for attributes [skip ci]

### DIFF
--- a/src/vaadin-radio-group.html
+++ b/src/vaadin-radio-group.html
@@ -145,6 +145,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Error to show when the input value is invalid.
+             * @attr {string} error-message
              * @type {string}
              */
             errorMessage: {


### PR DESCRIPTION
Connected to vaadin/vaadin-core#257

Note, this is a PR for `1.4` branch. When cherry-picking it to `1.5`, we need to also include `helperText` property.