### PR TITLE
fix: change checked condition on button removal 

### DIFF
--- a/src/vaadin-radio-group.html
+++ b/src/vaadin-radio-group.html
@@ -202,7 +202,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             this._filterRadioButtons(info.removedNodes).forEach(button => {
               button.removeEventListener('checked-changed', checkedChangedListener);
-              if (button.checked) {
+              if (button == this._checkedButton) {
                 this.value = undefined;
               }
             });

--- a/test/vaadin-radio-group.html
+++ b/test/vaadin-radio-group.html
@@ -578,6 +578,34 @@
         vaadinRadioButtonGroup._observer.flush();
         expect(vaadinRadioButtonGroup.value).to.not.be.equal('2');
       });
+
+      it('should work if value is set immediately after removing and adding new children', () => {
+        const items = [
+          {id: '1', name: 'item_1'},
+          {id: '2', name: 'item_2'},
+          {id: '3', name: 'item_3'},
+          {id: '4', name: 'item_4'}
+        ];
+        let buttonSelected = 0;
+        function removeAndAddChildrenAndSelectNext() {
+          Array.from(vaadinRadioButtonGroup.children).forEach(button => vaadinRadioButtonGroup.removeChild(button));
+          items.forEach(item => {
+            const radioButton = window.document.createElement('vaadin-radio-button');
+            radioButton.textContent = item.name;
+            radioButton.value = item.id;
+            vaadinRadioButtonGroup.appendChild(radioButton);
+          });
+          vaadinRadioButtonGroup.value = ++buttonSelected;
+        }
+
+        removeAndAddChildrenAndSelectNext();
+        vaadinRadioButtonGroup._observer.flush();
+        expect(+vaadinRadioButtonGroup.value).to.be.equal(buttonSelected);
+
+        removeAndAddChildrenAndSelectNext();
+        vaadinRadioButtonGroup._observer.flush();
+        expect(+vaadinRadioButtonGroup.value).to.be.equal(buttonSelected);
+      });
     });
 
     describe('radio-group-with-dom-repeat', () => {


### PR DESCRIPTION
Prior this change, the conditional checks whether the button being removed is checked or not, in order of resetting the group value.
That works well, unless a new button is checked right after the checked button is removed. Since the resetting logic is done inside a FlattenedNodesObserver, it happens asynchronously and the selected button being removed is no longer the actual value of the group, therefore no reset is needed.

Fix https://github.com/vaadin/vaadin-radio-button-flow/issues/108