### PR TITLE
I think the label should have 100% width allways

### DIFF
--- a/src/vaadin-radio-button.js
+++ b/src/vaadin-radio-button.js
@@ -59,6 +59,7 @@ class RadioButtonElement extends ElementMixin(ControlStateMixin(ThemableMixin(Ge
           display: inline-flex;
           align-items: baseline;
           outline: none;
+          width: 100%;
         }
 
         [part='radio'] {


### PR DESCRIPTION
Consider following case
- I want to add Renderer to RadioButtonGroup using ComponentRenderer
- I set RadioButtonGroup to be 100% width
- I place a component say TextField in the Renderer
- I set TextField to be 100% width

Furthermore I do

radiobutton.css
[part="label"]  {
    width: 100%;
}

@CssImport(value = "./styles/radiobutton.css", themeFor = "vaadin-radio-button")

I would expect TextField now fill the rest of the space occupied by RadioButtonGroup, but that is not happening as label is limiting the size.