### PR TITLE
fix: add missing import for Material theme

### DIFF
--- a/theme/material/vaadin-radio-group.html
+++ b/theme/material/vaadin-radio-group.html
@@ -1,2 +1,3 @@
+<link rel="import" href="vaadin-radio-button.html">
 <link rel="import" href="vaadin-radio-group-styles.html">
 <link rel="import" href="../../src/vaadin-radio-group.html">


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/661

## Type of change

- [x] Bugfix