### PR TITLE
fix: set has-value attribute on radio button click

### DIFF
--- a/src/vaadin-radio-group.html
+++ b/src/vaadin-radio-group.html
@@ -464,13 +464,13 @@ This program is available under Apache License Version 2.0, available at https:/
 
           if (!this._checkedButton || newV != this._checkedButton.value) {
             const newCheckedButton = this._radioButtons.filter(button => button.value == newV)[0];
+            this._selectButton(newCheckedButton);
+          }
 
-            if (newCheckedButton) {
-              this._selectButton(newCheckedButton);
-              this.setAttribute('has-value', '');
-            } else {
-              console.warn(`No <vaadin-radio-button> with value ${newV} found.`);
-            }
+          if (this._checkedButton) {
+            this.setAttribute('has-value', '');
+          } else {
+            console.warn(`No <vaadin-radio-button> with value ${newV} found.`);
           }
         }
 

--- a/test/vaadin-radio-group.html
+++ b/test/vaadin-radio-group.html
@@ -330,11 +330,19 @@
         expect(vaadinRadioButtonList[2].disabled).to.be.false;
       });
 
-      it('should not have the has-value attribute by default', () => {
+      it('should not have has-value attribute by default', () => {
         expect(vaadinRadioButtonGroup.hasAttribute('has-value')).to.be.false;
       });
 
-      it('should change the has-value attribute on value', () => {
+      it('should set has-value attribute on radio button click', () => {
+        vaadinRadioButtonList[0].click();
+        expect(vaadinRadioButtonGroup.hasAttribute('has-value')).to.be.true;
+
+        vaadinRadioButtonList[1].click();
+        expect(vaadinRadioButtonGroup.hasAttribute('has-value')).to.be.true;
+      });
+
+      it('should toggle has-value attribute on value change', () => {
         vaadinRadioButtonGroup.value = '2';
         expect(vaadinRadioButtonGroup.hasAttribute('has-value')).to.be.true;
 
@@ -378,6 +386,12 @@
         vaadinRadioButtonGroup.required = true;
         blur(vaadinRadioButtonGroup, false);
         expect(vaadinRadioButtonGroup.invalid).to.be.false;
+      });
+
+      it('should run validation only once on radio button click', () => {
+        const spy = sinon.spy(vaadinRadioButtonGroup, 'validate');
+        vaadinRadioButtonList[1].click();
+        expect(spy.calledOnce).to.be.true;
       });
 
       it('error should have appropriate aria attributes and id', () => {


### PR DESCRIPTION
## Description

The PR backports the fix from V21 for the bug where the `has-value` attribute isn't set on the radio-group element when the user selects a radio-button.

Closes https://github.com/vaadin/web-components/issues/2873.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
