### PR TITLE
fix!: prevent initial validation when radio-group is initialized as invalid 

### DIFF
--- a/src/vaadin-radio-group.html
+++ b/src/vaadin-radio-group.html
@@ -208,6 +208,7 @@ This program is available under Apache License Version 2.0, available at https:/
             value: {
               type: String,
               notify: true,
+              value: '',
               observer: '_valueChanged'
             }
           };
@@ -456,6 +457,9 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /** @private */
         _valueChanged(newV, oldV) {
+          if (oldV === undefined) {
+            return;
+          }
           if (oldV && (newV === '' || newV === null || newV === undefined)) {
             this._changeSelectedButton(null);
             this.removeAttribute('has-value');

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,8 +1,12 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
   "globals": {
     "WCT": false,
     "describe": false,
     "beforeEach": false,
+    "afterEach": false,
     "fixture": false,
     "it": false,
     "expect": false,

--- a/test/vaadin-radio-group.html
+++ b/test/vaadin-radio-group.html
@@ -801,5 +801,49 @@
         expect(wrappedRadios[0].getBoundingClientRect().left).to.equal(firstLeft);
       });
     });
+    describe('initial validation', () => {
+      let group, validateSpy;
+    
+      function nextRender(element) {
+        return new Promise(resolve => {
+          Polymer.RenderStatus.afterNextRender(element, resolve);
+        });
+      }
+    
+      beforeEach(() => {
+        group = document.createElement('vaadin-radio-group');
+
+        const radio = document.createElement('vaadin-radio-button');
+        radio.value = '1';
+        group.appendChild(radio);
+
+        validateSpy = sinon.spy(group, 'validate');
+      });
+
+      afterEach(() => {
+        group.remove();
+      });
+
+      it('should not validate by default', async() => {
+        document.body.appendChild(group);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate when the field has an initial value', async() => {
+        group.value = '1';
+        document.body.appendChild(group);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate when the field has an initial value and invalid', async() => {
+        group.value = '1';
+        group.invalid = true;
+        document.body.appendChild(group);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+    });
   </script>
 </body>


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

The PR prevents the initial validation that could previously take place when radio-group is initially provided with a non-empty value and is initially marked invalid.

This PR refers https://github.com/vaadin/web-components/pull/4156
As mentioned as Warning in the referred PR 
   #Warning 
   This PR is breaking because it changes the default value of the value property to an empty string.
   Without this change, it was not possible to distinguish whether the value has been changed manually via the property.

## Type of change

- [x] Bugfix

