### PR TITLE
fix!: prevent initial validation when radio-group is initialized as invalid

### DIFF
--- a/src/vaadin-radio-group.html
+++ b/src/vaadin-radio-group.html
@@ -208,6 +208,7 @@ This program is available under Apache License Version 2.0, available at https:/
             value: {
               type: String,
               notify: true,
+              value: '',
               observer: '_valueChanged'
             }
           };
@@ -456,6 +457,9 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /** @private */
         _valueChanged(newV, oldV) {
+          if (oldV === undefined) {
+            return;
+          }
           if (oldV && (newV === '' || newV === null || newV === undefined)) {
             this._changeSelectedButton(null);
             this.removeAttribute('has-value');

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,8 +1,12 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
   "globals": {
     "WCT": false,
     "describe": false,
     "beforeEach": false,
+    "afterEach": false,
     "fixture": false,
     "it": false,
     "expect": false,
@@ -10,6 +14,7 @@
     "sinon": false,
     "MockInteractions": false,
     "animationFrameFlush": false,
-    "flush": false
+    "flush": false,
+    "nextRender": false
   }
 }

--- a/test/helpers.html
+++ b/test/helpers.html
@@ -1,0 +1,14 @@
+<!doctype html>
+
+<head>
+  <link rel="import" href="../../polymer/polymer.html">
+</head>
+<body>
+<script>
+  window.nextRender = (element) => {
+    return new Promise(resolve => {
+      Polymer.RenderStatus.afterNextRender(element, resolve);
+    });
+  };
+</script>
+</body>

--- a/test/test-suites.js
+++ b/test/test-suites.js
@@ -1,4 +1,5 @@
 window.VaadinRadioButtonSuites = [
   'vaadin-radio-button.html',
-  'vaadin-radio-group.html'
+  'vaadin-radio-group.html',
+  'validation.html'
 ];

--- a/test/validation.html
+++ b/test/validation.html
@@ -1,0 +1,58 @@
+<!doctype html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>vaadin-radio-button tests</title>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../iron-test-helpers/mock-interactions.html">
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="../vaadin-radio-button.html">
+  <link rel="import" href="../vaadin-radio-group.html">
+  <link rel="import" href="helpers.html">
+</head>
+
+<body>
+ <script>
+ 
+ describe('initial validation', () => {
+   let group, validateSpy;
+
+   beforeEach(() => {
+     group = document.createElement('vaadin-radio-group');
+
+     const radio = document.createElement('vaadin-radio-button');
+     radio.value = '1';
+     group.appendChild(radio);
+
+     validateSpy = sinon.spy(group, 'validate');
+   });
+
+   afterEach(() => {
+     group.remove();
+   });
+
+   it('should not validate by default', async() => {
+     document.body.appendChild(group);
+     await nextRender();
+     expect(validateSpy.called).to.be.false;
+   });
+
+   it('should not validate when the field has an initial value', async() => {
+     group.value = '1';
+     document.body.appendChild(group);
+     await nextRender();
+     expect(validateSpy.called).to.be.false;
+   });
+
+   it('should not validate when the field has an initial value and invalid', async() => {
+     group.value = '1';
+     group.invalid = true;
+     document.body.appendChild(group);
+     await nextRender();
+     expect(validateSpy.called).to.be.false;
+   });
+ });
+ 
+ </script>
+</body>


### PR DESCRIPTION
## Description

Backports the following PRs:

- https://github.com/vaadin/web-components/pull/4156/

Part of https://github.com/vaadin/web-components/issues/5763