### PR TITLE
fix: prevent selecting on mouseup outside the radio-button

### DIFF
--- a/src/vaadin-radio-button.html
+++ b/src/vaadin-radio-button.html
@@ -233,6 +233,13 @@ This program is available under Apache License Version 2.0, available at https:/
           this._addEventListenerToNode(this, 'up', (e) => {
             this.removeAttribute('active');
 
+            // Prevent selecting if pointer has left the component
+            // https://github.com/vaadin/web-components/issues/442
+            const event = e.detail && e.detail.sourceEvent;
+            if (event && Array.from(event.composedPath()).indexOf(this) === -1) {
+              return;
+            }
+
             if (!this.checked && !this.disabled) {
               // If you change this block, please test manually that radio-button and
               // radio-group still works ok on iOS 12/13 and up as it may cause

--- a/test/vaadin-radio-button.html
+++ b/test/vaadin-radio-button.html
@@ -129,6 +129,15 @@
         expect(vaadinRadioButton.checked).to.be.true;
       });
 
+      it('should not be checked after mouseup outside the element', () => {
+        // Mimic the Polymer 'up' gesture event behavior
+        vaadinRadioButton.dispatchEvent(new MouseEvent('mousedown'));
+        const event = new MouseEvent('mouseup', {composed: true});
+        sinon.stub(event, 'composedPath').returns([document]);
+        document.dispatchEvent(event);
+        expect(vaadinRadioButton.checked).to.be.false;
+      });
+
       it('should have active attribute on space', () => {
         MockInteractions.keyDownOn(vaadinRadioButton, 32);
         expect(vaadinRadioButton.hasAttribute('active')).to.be.true;

--- a/test/vaadin-radio-button.html
+++ b/test/vaadin-radio-button.html
@@ -133,7 +133,6 @@
         // Mimic the Polymer 'up' gesture event behavior
         vaadinRadioButton.dispatchEvent(new MouseEvent('mousedown'));
         const event = new MouseEvent('mouseup', {composed: true});
-        sinon.stub(event, 'composedPath').returns([document]);
         document.dispatchEvent(event);
         expect(vaadinRadioButton.checked).to.be.false;
       });


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/442

Added logic to ensure `mouseup` event fired outside the `vaadin-radio-button` element doesn't make it selected.
This is needed because of the way how Polymer `downup` gesture is implemented, especially [`trackDocument()`](https://github.com/Polymer/polymer/blob/1e8b246d01ea99adba305ea04c45d26da31f68f1/lib/utils/gestures.js#L761).

## Type of change

- Bugfix