### PR TITLE
fix: detect actual target of the touchend or mouseup event

### DIFF
--- a/src/vaadin-radio-button.html
+++ b/src/vaadin-radio-button.html
@@ -229,6 +229,11 @@ This program is available under Apache License Version 2.0, available at https:/
             if (!this.disabled) {
               this.setAttribute('active', '');
             }
+
+            // Store the original event coordinates.
+            const event = e.detail && e.detail.sourceEvent;
+            this.__downX = event && event.clientX;
+            this.__downY = event && event.clientY;
           });
 
           this._addEventListenerToNode(this, 'up', (e) => {
@@ -244,6 +249,14 @@ This program is available under Apache License Version 2.0, available at https:/
               // Prevent selecting if pointer has left the component
               // https://github.com/vaadin/web-components/issues/442
               if (target !== this && !this.shadowRoot.contains(target)) {
+                return;
+              }
+
+              // Prevent selecting if touch point moved within the component.
+              if (
+                (this.__downX && event.clientX !== this.__downX) ||
+                (this.__downY && event.clientY !== this.__downY)
+              ) {
                 return;
               }
             }

--- a/src/vaadin-radio-button.html
+++ b/src/vaadin-radio-button.html
@@ -6,6 +6,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
 <link rel="import" href="../../polymer/polymer-element.html">
 <link rel="import" href="../../polymer/lib/mixins/gesture-event-listeners.html">
+<link rel="import" href="../../polymer/lib/utils/gestures.html">
 <link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
 <link rel="import" href="../../vaadin-control-state-mixin/vaadin-control-state-mixin.html">
 <link rel="import" href="../../vaadin-element-mixin/vaadin-element-mixin.html">
@@ -233,11 +234,18 @@ This program is available under Apache License Version 2.0, available at https:/
           this._addEventListenerToNode(this, 'up', (e) => {
             this.removeAttribute('active');
 
-            // Prevent selecting if pointer has left the component
-            // https://github.com/vaadin/web-components/issues/442
             const event = e.detail && e.detail.sourceEvent;
-            if (event && Array.from(event.composedPath()).indexOf(this) === -1) {
-              return;
+            if (event) {
+              // According to spec, the `touchend` event target is the same element
+              // on which the touch point started, even if the touch point has since
+              // moved outside that element. So we need to detect the proper target.
+              const target = Polymer.Gestures.deepTargetFind(event.clientX, event.clientY);
+
+              // Prevent selecting if pointer has left the component
+              // https://github.com/vaadin/web-components/issues/442
+              if (target !== this && !this.shadowRoot.contains(target)) {
+                return;
+              }
             }
 
             if (!this.checked && !this.disabled) {

--- a/test/vaadin-radio-button.html
+++ b/test/vaadin-radio-button.html
@@ -129,11 +129,37 @@
         expect(vaadinRadioButton.checked).to.be.true;
       });
 
+      it('should be checked after mouseup inside the element', () => {
+        // Mimic the Polymer 'up' gesture event behavior
+        nativeRadio.dispatchEvent(new CustomEvent('mousedown', {bubbles: true, composed: true}));
+        const event = new CustomEvent('mouseup', {bubbles: true, composed: true});
+        const xy = MockInteractions.middleOfNode(nativeRadio);
+        event.clientX = xy.x;
+        event.clientY = xy.y;
+        nativeRadio.dispatchEvent(event);
+        expect(vaadinRadioButton.checked).to.be.true;
+      });
+
       it('should not be checked after mouseup outside the element', () => {
         // Mimic the Polymer 'up' gesture event behavior
-        vaadinRadioButton.dispatchEvent(new MouseEvent('mousedown'));
-        const event = new MouseEvent('mouseup', {composed: true});
+        nativeRadio.dispatchEvent(new CustomEvent('mousedown', {bubbles: true, composed: true}));
+        const event = new CustomEvent('mouseup', {bubbles: true, composed: true});
+        event.clientX = 200;
+        event.clientY = 200;
         document.dispatchEvent(event);
+        expect(vaadinRadioButton.checked).to.be.false;
+      });
+
+      it('should be checked after touchend inside the element', () => {
+        MockInteractions.touchstart(vaadinRadioButton);
+        MockInteractions.touchend(vaadinRadioButton);
+        expect(vaadinRadioButton.checked).to.be.true;
+      });
+
+      it('should not be checked after touchend outside the element', () => {
+        const xy = MockInteractions.middleOfNode(nativeRadio);
+        MockInteractions.makeSoloTouchEvent('touchstart', xy, vaadinRadioButton);
+        MockInteractions.makeSoloTouchEvent('touchend', {clientX: 200, clientY: 200}, vaadinRadioButton);
         expect(vaadinRadioButton.checked).to.be.false;
       });
 

--- a/test/vaadin-radio-button.html
+++ b/test/vaadin-radio-button.html
@@ -159,7 +159,14 @@
       it('should not be checked after touchend outside the element', () => {
         const xy = MockInteractions.middleOfNode(nativeRadio);
         MockInteractions.makeSoloTouchEvent('touchstart', xy, vaadinRadioButton);
-        MockInteractions.makeSoloTouchEvent('touchend', {clientX: 200, clientY: 200}, vaadinRadioButton);
+        MockInteractions.makeSoloTouchEvent('touchend', {x: 200, y: 200}, vaadinRadioButton);
+        expect(vaadinRadioButton.checked).to.be.false;
+      });
+
+      it('should not be checked after moving touch point within the element', () => {
+        const xy = MockInteractions.middleOfNode(nativeRadio);
+        MockInteractions.makeSoloTouchEvent('touchstart', xy, vaadinRadioButton);
+        MockInteractions.makeSoloTouchEvent('touchend', {x: xy.x + 5, y: xy.y + 5}, vaadinRadioButton);
         expect(vaadinRadioButton.checked).to.be.false;
       });
 


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/6911

The original fix only worked for `mouseup` event and was causing an error on touch devices.
When investigating this further, I realised that we can't rely on `event.composedPath()` anyway.

Luckily there is a helper in Polymer to get the actual target using event coordinates.
Updated the `up` event listener to use it. Also, extended unit tests accordingly.

## Type of change

- Bugfix